### PR TITLE
fix: update nuxt version constraint

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -26,7 +26,7 @@ export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: 'nuxt-monaco-editor',
     configKey: 'monacoEditor',
-    compatibility: { nuxt: '^3.0.0' }
+    compatibility: { nuxt: '^3.0.0-rc.8' }
   },
   defaults: DEFAULTS,
   setup (options, nuxt) {


### PR DESCRIPTION
In https://github.com/nuxt/framework/pull/7116 we made a breaking change allowing modules to use RC constraints. This PR fixes this.