### PR TITLE
docs: remove the descriptions of dest in the document

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ export default defineNuxtConfig({
 export default defineNuxtConfig({
   monacoEditor: {
     // These are default values:
-    dest: '_monaco',
     locale: 'en',
     componentName: {
       codeEditor: 'MonacoEditor',

--- a/docs/content/1.guide/2.configuration.md
+++ b/docs/content/1.guide/2.configuration.md
@@ -1,7 +1,6 @@
 # Configuration
 ```ts
 export interface ModuleOptions {
-  dest?: string,
   locale?: MonacoEditorLocale,
   componentName?: {
     codeEditor?: string,
@@ -10,7 +9,6 @@ export interface ModuleOptions {
 }
 
 const DEFAULTS: ModuleOptions = {
-  dest: '_monaco',
   locale: 'en',
   componentName: {
     codeEditor: 'MonacoEditor',
@@ -18,10 +16,6 @@ const DEFAULTS: ModuleOptions = {
   }
 }
 ```
-
-## `dest`
-
-Set where monaco-editor should be placed after build. This path will append to `app.baseURL` of nuxt.config.
 
 ## `locale`
 

--- a/docs/content/ja/1.guide/2.configuration.md
+++ b/docs/content/ja/1.guide/2.configuration.md
@@ -1,7 +1,6 @@
 # 設定
 ```ts
 export interface ModuleOptions {
-  dest?: string,
   locale?: MonacoEditorLocale,
   componentName?: {
     codeEditor?: string,
@@ -10,7 +9,6 @@ export interface ModuleOptions {
 }
 
 const DEFAULTS: ModuleOptions = {
-  dest: '_monaco',
   locale: 'en',
   componentName: {
     codeEditor: 'MonacoEditor',
@@ -18,10 +16,6 @@ const DEFAULTS: ModuleOptions = {
   }
 }
 ```
-
-## `dest`
-
-ビルド後のmonaco-editorの配置先を設定します。Nuxtの設定の`app.baseURL`に追加して配置されます。
 
 ## `locale`
 


### PR DESCRIPTION
Remove the descriptions of dest in the document.

Since v1.2.0, dest has been removed from ModuleOptions.

https://github.com/e-chan1007/nuxt-monaco-editor/blob/43e7fede10ce67bb08ff2fdf321a7f79a66e7f4f/src/module.ts#L8-L14