### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -1,5 +1,5 @@
 import type * as Monaco from 'monaco-editor'
-import { useState } from '#app'
+import { useState } from '#imports'
 
 export const _useMonacoState = () => useState<typeof Monaco | null>('MonacoEditorNamespace', () => null)
 /**

--- a/src/runtime/plugin-dev.client.ts
+++ b/src/runtime/plugin-dev.client.ts
@@ -1,5 +1,5 @@
 import { _useMonacoState } from './composables'
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 
 export default defineNuxtPlugin(async (nuxtApp) => {
   const getWorkerModule = (moduleUrl: string, label: string) => {

--- a/src/runtime/plugin-prod.client.ts
+++ b/src/runtime/plugin-prod.client.ts
@@ -1,5 +1,5 @@
 import { _useMonacoState } from './composables'
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 
 export default defineNuxtPlugin(async (nuxtApp) => {
   const getWorkerModule = (moduleUrl: string, label: string) => {


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.