### PR TITLE
fix: use `watch` for the target element

### DIFF
--- a/src/runtime/MonacoDiffEditor.client.vue
+++ b/src/runtime/MonacoDiffEditor.client.vue
@@ -6,7 +6,7 @@
 
 <script lang="ts" setup>
 import type * as Monaco from 'monaco-editor'
-import { onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
+import { onBeforeUnmount, ref, shallowRef, watch } from 'vue'
 import { defu } from 'defu'
 import { useMonaco } from './composables'
 
@@ -44,8 +44,8 @@ const monaco = useMonaco()!
 let editor: Monaco.editor.IStandaloneDiffEditor
 let originalModel: Monaco.editor.ITextModel
 let modifiedModel: Monaco.editor.ITextModel
-const editorRef = shallowRef<Monaco.editor.IStandaloneDiffEditor>()
 
+const editorRef = shallowRef<Monaco.editor.IStandaloneDiffEditor>()
 const defaultOptions: Monaco.editor.IStandaloneEditorConstructionOptions = {
   automaticLayout: true
 }
@@ -81,7 +81,8 @@ defineExpose({
   $editor: editorRef
 })
 
-onMounted(() => {
+watch(editorElement, (newValue, oldValue) => {
+  if (!editorElement.value || oldValue) { return }
   editor = monaco.editor.createDiffEditor(editorElement.value!, defu(props.options, defaultOptions))
   editorRef.value = editor
   originalModel = monaco.editor.createModel(props.original, props.lang)
@@ -99,7 +100,7 @@ onMounted(() => {
   emit('load', editor)
 })
 
-onUnmounted(() => {
+onBeforeUnmount(() => {
   editor?.dispose()
   originalModel?.dispose()
   modifiedModel?.dispose()

--- a/src/runtime/MonacoEditor.client.vue
+++ b/src/runtime/MonacoEditor.client.vue
@@ -6,8 +6,9 @@
 
 <script lang="ts" setup>
 import type * as Monaco from "monaco-editor"
-import { computed, ref, shallowRef, watch } from "vue"
+import { computed, ref, shallowRef, watch, onBeforeUnmount } from "vue"
 import { defu } from "defu"
+import { useMonaco } from './composables'
 
 interface Props {
     /**

--- a/src/runtime/MonacoEditor.client.vue
+++ b/src/runtime/MonacoEditor.client.vue
@@ -5,85 +5,89 @@
 </template>
 
 <script lang="ts" setup>
-import type * as Monaco from 'monaco-editor'
-import { computed, onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
-import { defu } from 'defu'
-import { useMonaco } from './composables'
+import type * as Monaco from "monaco-editor"
+import { computed, ref, shallowRef, watch } from "vue"
+import { defu } from "defu"
 
 interface Props {
-  /**
-   * Programming Language (Not a locale for UI);
-   * overrides `options.language`
-   */
-  lang?: string;
-  /**
-   * Options passed to the second argument of `monaco.editor.create`
-   */
-  options?: Monaco.editor.IStandaloneEditorConstructionOptions;
-  modelValue?: string;
+    /**
+     * Programming Language (Not a locale for UI);
+     * overrides `options.language`
+     */
+    lang?: string;
+    /**
+     * Options passed to the second argument of `monaco.editor.create`
+     */
+    options?: Monaco.editor.IStandaloneEditorConstructionOptions;
+    modelValue?: string;
 }
 
 interface Emits {
-  (event: 'update:modelValue', value: string): void
-  (event: 'load', editor: Monaco.editor.IStandaloneCodeEditor): void
+    (event: "update:modelValue", value: string): void
+
+    (event: "load", editor: Monaco.editor.IStandaloneCodeEditor): void
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  lang: () => 'plaintext',
-  options: () => ({}),
-  modelValue: () => ''
+    lang: () => "plaintext",
+    options: () => ( {} ),
+    modelValue: () => ""
 })
+
 const emit = defineEmits<Emits>()
 const isLoading = ref(true)
-
 const lang = computed(() => props.lang || props.options.language)
-
-const editorElement = shallowRef<HTMLDivElement>()
+const editorRef = shallowRef<Monaco.editor.IStandaloneCodeEditor>()
+const editorElement = ref<HTMLDivElement>()
 const monaco = useMonaco()!
+const defaultOptions: Monaco.editor.IStandaloneEditorConstructionOptions = {
+    automaticLayout: true
+}
 
 let editor: Monaco.editor.IStandaloneCodeEditor
 let model: Monaco.editor.ITextModel
-const editorRef = shallowRef<Monaco.editor.IStandaloneCodeEditor>()
-
-const defaultOptions: Monaco.editor.IStandaloneEditorConstructionOptions = {
-  automaticLayout: true
-}
 
 watch(() => props.modelValue, () => {
-  if (editor?.getValue() !== props.modelValue) { editor?.setValue(props.modelValue) }
+    if (editor?.getValue() !== props.modelValue) {
+        editor?.setValue(props.modelValue)
+    }
 })
 
 watch(() => props.lang, () => {
-  if (model) { model.dispose() }
-  model = monaco.editor.createModel(props.modelValue, lang.value)
-  editor?.setModel(model)
+    if (model) {
+        model.dispose()
+    }
+    model = monaco.editor.createModel(props.modelValue, lang.value)
+    editor?.setModel(model)
 })
 
 watch(() => props.options, () => {
-  editor?.updateOptions(defu(props.options, defaultOptions))
+    editor?.updateOptions(defu(props.options, defaultOptions))
+})
+
+watch(editorElement, (newValue, oldValue) => {
+    if (!editorElement.value || oldValue) return
+    editor = monaco.editor.create(editorElement.value!, defu(props.options, defaultOptions))
+    model = monaco.editor.createModel(props.modelValue, lang.value)
+    editorRef.value = editor
+    editor.layout()
+    editor.setModel(model)
+    editor.onDidChangeModelContent(() => {
+        emit("update:modelValue", editor.getValue())
+    })
+    isLoading.value = false
+    emit("load", editor)
 })
 
 defineExpose({
-  /**
-   * Monaco editor instance
-   */
-  $editor: editorRef
+    /**
+     * Monaco editor instance
+     */
+    $editor: editorRef
 })
 
-onMounted(() => {
-  editor = monaco.editor.create(editorElement.value!, defu(props.options, defaultOptions))
-  editorRef.value = editor
-  model = monaco.editor.createModel(props.modelValue, lang.value)
-  editor.setModel(model)
-  editor.onDidChangeModelContent(() => {
-    emit('update:modelValue', editor.getValue())
-  })
-  isLoading.value = false
-  emit('load', editor)
-})
-
-onUnmounted(() => {
-  editor?.dispose()
-  model?.dispose()
+onBeforeUnmount(() => {
+    editor?.dispose()
+    model?.dispose()
 })
 </script>

--- a/src/runtime/MonacoEditor.client.vue
+++ b/src/runtime/MonacoEditor.client.vue
@@ -5,9 +5,9 @@
 </template>
 
 <script lang="ts" setup>
-import type * as Monaco from "monaco-editor"
-import { computed, ref, shallowRef, watch, onBeforeUnmount } from "vue"
-import { defu } from "defu"
+import type * as Monaco from 'monaco-editor'
+import { computed, ref, shallowRef, watch, onBeforeUnmount } from 'vue'
+import { defu } from 'defu'
 import { useMonaco } from './composables'
 
 interface Props {
@@ -24,15 +24,14 @@ interface Props {
 }
 
 interface Emits {
-    (event: "update:modelValue", value: string): void
-
-    (event: "load", editor: Monaco.editor.IStandaloneCodeEditor): void
+    (event: 'update:modelValue', value: string): void
+    (event: 'load', editor: Monaco.editor.IStandaloneCodeEditor): void
 }
 
 const props = withDefaults(defineProps<Props>(), {
-    lang: () => "plaintext",
-    options: () => ( {} ),
-    modelValue: () => ""
+  lang: () => 'plaintext',
+  options: () => ({}),
+  modelValue: () => ''
 })
 
 const emit = defineEmits<Emits>()
@@ -42,53 +41,53 @@ const editorRef = shallowRef<Monaco.editor.IStandaloneCodeEditor>()
 const editorElement = ref<HTMLDivElement>()
 const monaco = useMonaco()!
 const defaultOptions: Monaco.editor.IStandaloneEditorConstructionOptions = {
-    automaticLayout: true
+  automaticLayout: true
 }
 
 let editor: Monaco.editor.IStandaloneCodeEditor
 let model: Monaco.editor.ITextModel
 
 watch(() => props.modelValue, () => {
-    if (editor?.getValue() !== props.modelValue) {
-        editor?.setValue(props.modelValue)
-    }
+  if (editor?.getValue() !== props.modelValue) {
+    editor?.setValue(props.modelValue)
+  }
 })
 
 watch(() => props.lang, () => {
-    if (model) {
-        model.dispose()
-    }
-    model = monaco.editor.createModel(props.modelValue, lang.value)
-    editor?.setModel(model)
+  if (model) {
+    model.dispose()
+  }
+  model = monaco.editor.createModel(props.modelValue, lang.value)
+  editor?.setModel(model)
 })
 
 watch(() => props.options, () => {
-    editor?.updateOptions(defu(props.options, defaultOptions))
+  editor?.updateOptions(defu(props.options, defaultOptions))
 })
 
 watch(editorElement, (newValue, oldValue) => {
-    if (!editorElement.value || oldValue) return
-    editor = monaco.editor.create(editorElement.value!, defu(props.options, defaultOptions))
-    model = monaco.editor.createModel(props.modelValue, lang.value)
-    editorRef.value = editor
-    editor.layout()
-    editor.setModel(model)
-    editor.onDidChangeModelContent(() => {
-        emit("update:modelValue", editor.getValue())
-    })
-    isLoading.value = false
-    emit("load", editor)
+  if (!editorElement.value || oldValue) { return }
+  editor = monaco.editor.create(editorElement.value!, defu(props.options, defaultOptions))
+  model = monaco.editor.createModel(props.modelValue, lang.value)
+  editorRef.value = editor
+  editor.layout()
+  editor.setModel(model)
+  editor.onDidChangeModelContent(() => {
+    emit('update:modelValue', editor.getValue())
+  })
+  isLoading.value = false
+  emit('load', editor)
 })
 
 defineExpose({
-    /**
+  /**
      * Monaco editor instance
      */
-    $editor: editorRef
+  $editor: editorRef
 })
 
 onBeforeUnmount(() => {
-    editor?.dispose()
-    model?.dispose()
+  editor?.dispose()
+  model?.dispose()
 })
 </script>


### PR DESCRIPTION
Instead of `onMounted` we use a watch which guarantees the target element will be available for attaching the editor instance, also switch to `onBeforeUnmount`

Fixes https://github.com/e-chan1007/nuxt-monaco-editor/issues/46