### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,7 @@ Integrate [monaco-editor](https://microsoft.github.io/monaco-editor/) with Nuxt
 
 ## Install
 ```sh
-# npm
-npm install -D monaco-editor nuxt-monaco-editor
-
-# yarn
-yarn add -D monaco-editor nuxt-monaco-editor
-
-# pnpm
-pnpm add -D monaco-editor nuxt-monaco-editor
+npx nuxi@latest module add nuxt-monaco-editor
 ```
 Don't forget to install `monaco-editor`.
 

--- a/docs/content/0.index.md
+++ b/docs/content/0.index.md
@@ -11,7 +11,7 @@ cta:
 secondary:
 - Open on GitHub →
 - https://github.com/e-chan1007/nuxt-monaco-editor
-snippet: npm install -D monaco-editor nuxt-monaco-editor
+snippet: npx nuxi@latest module add nuxt-monaco-editor
 ---
 
 #title

--- a/docs/content/1.guide/1.getting-started.md
+++ b/docs/content/1.guide/1.getting-started.md
@@ -1,19 +1,8 @@
 # Getting started
 ## Install
-
-::code-group
-  ```bash [npm]
-  npm install -D monaco-editor nuxt-monaco-editor
-  ```
-
-  ```bash [yarn]
-  yarn add -D monaco-editor nuxt-monaco-editor
-  ```
-
-  ```bash [pnpm]
-  pnpm add -D monaco-editor nuxt-monaco-editor
-  ```
-::
+```bash
+npx nuxi@latest module add nuxt-monaco-editor
+```
 
 Don't forget to install `monaco-editor`.
 

--- a/docs/content/ja/0.index.md
+++ b/docs/content/ja/0.index.md
@@ -11,7 +11,7 @@ cta:
 secondary:
 - GitHubで見る →
 - https://github.com/e-chan1007/nuxt-monaco-editor
-snippet: npm install -D monaco-editor nuxt-monaco-editor
+snippet: npx nuxi@latest module add nuxt-monaco-editor
 ---
 
 #title

--- a/docs/content/ja/1.guide/1.getting-started.md
+++ b/docs/content/ja/1.guide/1.getting-started.md
@@ -1,19 +1,8 @@
 # はじめる
 ## インストール
-
-::code-group
-  ```bash [npm]
-  npm install -D monaco-editor nuxt-monaco-editor
-  ```
-
-  ```bash [yarn]
-  yarn add -D monaco-editor nuxt-monaco-editor
-  ```
-
-  ```bash [pnpm]
-  pnpm add -D monaco-editor nuxt-monaco-editor
-  ```
-::
+```bash
+npx nuxi@latest module add nuxt-monaco-editor
+```
 
 `monaco-editor` のインストールを忘れないよう注意してください。
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
