### PR TITLE
chore: package exports add types

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
   "exports": {
     ".": {
       "import": "./dist/module.mjs",
-      "require": "./dist/module.cjs"
+      "require": "./dist/module.cjs",
+      "types": "./dist/types.d.ts"
     },
     "./dist/*": {
-      "import": "./dist/*"
+      "import": "./dist/*",
+      "types": "./dist/types.d.ts"
     }
   },
   "main": "./dist/module.cjs",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
       "types": "./dist/types.d.ts"
     },
     "./dist/*": {
-      "import": "./dist/*",
-      "types": "./dist/types.d.ts"
+      "import": "./dist/*"
     }
   },
   "main": "./dist/module.cjs",


### PR DESCRIPTION
At nuxt.config.ts, it reslove type schema from config item `exports types` by the tsconfig `"moduleResolution": "Bundler"`

![image](https://github.com/e-chan1007/nuxt-monaco-editor/assets/74761884/b527e1ab-8569-4764-99f7-3fc81b8f3aeb)

![image](https://github.com/e-chan1007/nuxt-monaco-editor/assets/74761884/51ed5a58-4beb-4ad4-8a67-5f145308119a)
