### PR TITLE
Fix monaco-editor imports in runtime components

### DIFF
--- a/src/runtime/MonacoDiffEditor.client.vue
+++ b/src/runtime/MonacoDiffEditor.client.vue
@@ -5,7 +5,9 @@
 </template>
 
 <script lang="ts" setup>
-import type * as Monaco from 'monaco-editor'
+import { Uri } from 'monaco-editor/esm/vs/base/common/uri'
+import { ITextModel } from 'monaco-editor/esm/vs/editor/common/model'
+import { IStandaloneDiffEditor, IStandaloneDiffEditorConstructionOptions } from 'monaco-editor/esm/vs/editor/standalone/browser/standaloneEditor'
 import { onBeforeUnmount, ref, shallowRef, watch } from 'vue'
 import { defu } from 'defu'
 import { useMonaco } from './composables'
@@ -19,18 +21,18 @@ interface Props {
   /**
    * Options passed to the second argument of `monaco.editor.createDiffEditor`
    */
-  options?: Monaco.editor.IStandaloneDiffEditorConstructionOptions;
+  options?: IStandaloneDiffEditorConstructionOptions;
   /**
    * The URI that identifies models
    */
   // eslint-disable-next-line vue/require-default-prop
-  originalModelUri?: Monaco.Uri;
+  originalModelUri?: Uri;
 
   /**
    * The URI that identifies models
    */
   // eslint-disable-next-line vue/require-default-prop
-  modelUri?: Monaco.Uri;
+  modelUri?: Uri;
 
   original?: string;
   modelValue?: string;
@@ -38,7 +40,7 @@ interface Props {
 
 interface Emits {
   (event: 'update:modelValue', value: string): void
-  (event: 'load', editor: Monaco.editor.IStandaloneDiffEditor): void
+  (event: 'load', editor: IStandaloneDiffEditor): void
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -53,12 +55,12 @@ const isLoading = ref(true)
 const editorElement = shallowRef<HTMLDivElement>()
 const monaco = useMonaco()!
 
-let editor: Monaco.editor.IStandaloneDiffEditor
-let originalModel: Monaco.editor.ITextModel
-let modifiedModel: Monaco.editor.ITextModel
+let editor: IStandaloneDiffEditor
+let originalModel: ITextModel
+let modifiedModel: ITextModel
 
-const editorRef = shallowRef<Monaco.editor.IStandaloneDiffEditor>()
-const defaultOptions: Monaco.editor.IStandaloneEditorConstructionOptions = {
+const editorRef = shallowRef<IStandaloneDiffEditor>()
+const defaultOptions: IStandaloneDiffEditorConstructionOptions = {
   automaticLayout: true
 }
 

--- a/src/runtime/MonacoEditor.client.vue
+++ b/src/runtime/MonacoEditor.client.vue
@@ -5,7 +5,9 @@
 </template>
 
 <script lang="ts" setup>
-import * as Monaco from 'monaco-editor'
+import { Uri } from 'monaco-editor/esm/vs/base/common/uri'
+import { ITextModel } from 'monaco-editor/esm/vs/editor/common/model';
+import { IStandaloneEditorConstructionOptions } from 'monaco-editor/esm/vs/editor/standalone/browser/standaloneEditor'
 import { computed, ref, shallowRef, watch, onBeforeUnmount } from 'vue'
 import { defu } from 'defu'
 import { useMonaco } from './composables'
@@ -19,19 +21,19 @@ interface Props {
     /**
      * Options passed to the second argument of `monaco.editor.create`
      */
-    options?: Monaco.editor.IStandaloneEditorConstructionOptions;
+    options?: IStandaloneEditorConstructionOptions;
     /**
      * The URI that identifies models
      */
     // eslint-disable-next-line vue/require-default-prop
-    modelUri?: Monaco.Uri;
+    modelUri?: Uri;
 
     modelValue?: string;
 }
 
 interface Emits {
     (event: 'update:modelValue', value: string): void
-    (event: 'load', editor: Monaco.editor.IStandaloneCodeEditor): void
+    (event: 'load', editor: IStandaloneCodeEditor): void
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -43,15 +45,15 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<Emits>()
 const isLoading = ref(true)
 const lang = computed(() => props.lang || props.options.language)
-const editorRef = shallowRef<Monaco.editor.IStandaloneCodeEditor>()
+const editorRef = shallowRef<IStandaloneCodeEditor>()
 const editorElement = ref<HTMLDivElement>()
 const monaco = useMonaco()!
-const defaultOptions: Monaco.editor.IStandaloneEditorConstructionOptions = {
+const defaultOptions: IStandaloneEditorConstructionOptions = {
   automaticLayout: true
 }
 
-let editor: Monaco.editor.IStandaloneCodeEditor
-let model: Monaco.editor.ITextModel
+let editor: IStandaloneCodeEditor
+let model: ITextModel
 
 watch(() => props.modelValue, () => {
   if (editor?.getValue() !== props.modelValue) {


### PR DESCRIPTION
Fixes #66

- vibe coded appropriate imports from monaco-editor
- fixed some small type mistakes

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/e-chan1007/nuxt-monaco-editor/pull/67?shareId=4b61b0af-68c3-4b52-b5e7-1124912ed88d).