### PR TITLE
fix: update monaco-editor to version 0.56.0 and fix broken paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,28 @@
 # Nuxt Monaco Editor
+
 [![npm version](https://badge.fury.io/js/nuxt-monaco-editor.svg)](https://badge.fury.io/js/nuxt-monaco-editor)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/8b4585be9901491795f8b3c2f5dbb680)](https://www.codacy.com/gh/e-chan1007/nuxt-monaco-editor/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=e-chan1007/nuxt-monaco-editor&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/8b4585be9901491795f8b3c2f5dbb680)](https://www.codacy.com/gh/e-chan1007/nuxt-monaco-editor/dashboard?utm_source=github.com&utm_medium=referral&utm_content=e-chan1007/nuxt-monaco-editor&utm_campaign=Badge_Grade)
 [![Test result](https://github.com/e-chan1007/nuxt-monaco-editor/actions/workflows/test.yml/badge.svg)](https://github.com/e-chan1007/nuxt-monaco-editor/actions/workflows/test.yml)
 
 Integrate [monaco-editor](https://microsoft.github.io/monaco-editor/) with Nuxt
 
 ## Install
+
 ```sh
 npx nuxi@latest module add nuxt-monaco-editor
 ```
+
 Don't forget to install `monaco-editor`.
 
 ## Setup
+
 1. Add this module to the Nuxt config
 
 ```ts
 export default defineNuxtConfig({
-  modules: [
-    'nuxt-monaco-editor'
-  ]
-})
+  modules: ["nuxt-monaco-editor"],
+});
 ```
 
 2. (Optional) Configure the module
@@ -29,13 +31,13 @@ export default defineNuxtConfig({
 export default defineNuxtConfig({
   monacoEditor: {
     // These are default values:
-    locale: 'en',
+    locale: "en",
     componentName: {
-      codeEditor: 'MonacoEditor',
-      diffEditor: 'MonacoDiffEditor'
-    }
-  }
-})
+      codeEditor: "MonacoEditor",
+      diffEditor: "MonacoDiffEditor",
+    },
+  },
+});
 ```
 
 3. Use the component in your pages or components
@@ -46,11 +48,12 @@ export default defineNuxtConfig({
 </template>
 
 <script lang="ts" setup>
-const value = ref('')
+const value = ref("");
 </script>
 ```
 
 ## Development
 
+- Run `git submodule update --init --recursive`.
 - Run `pnpm dev:prepare` to generate type stubs.
 - Use `pnpm dev` to start [playground](./playground) in development mode.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint": "^10.3.0",
     "jiti": "^2.7.0",
     "lefthook": "^2.1.6",
-    "monaco-editor": "^0.55.1",
+    "monaco-editor": "^0.56.0",
     "nuxt": "^4.4.4",
     "pinst": "^3.0.0",
     "playwright-core": "^1.54.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^2.1.6
         version: 2.1.6
       monaco-editor:
-        specifier: ^0.55.1
-        version: 0.55.1
+        specifier: ^0.56.0
+        version: 0.56.0
       nuxt:
         specifier: ^4.4.4
         version: 4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.1)(typescript@6.0.3)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.4))(vue-tsc@3.2.8(typescript@6.0.3))(yaml@2.8.4)
@@ -4743,11 +4743,11 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.2.7:
-    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
-
   dompurify@3.4.2:
     resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
+
+  dompurify@3.4.8:
+    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -6399,8 +6399,8 @@ packages:
     resolution: {integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==}
     engines: {node: '>=0.10.0'}
 
-  monaco-editor@0.55.1:
-    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
+  monaco-editor@0.56.0:
+    resolution: {integrity: sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -13571,11 +13571,11 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.2.7:
+  dompurify@3.4.2:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
-  dompurify@3.4.2:
+  dompurify@3.4.8:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -15641,9 +15641,9 @@ snapshots:
 
   modify-values@1.0.1: {}
 
-  monaco-editor@0.55.1:
+  monaco-editor@0.56.0:
     dependencies:
-      dompurify: 3.2.7
+      dompurify: 3.4.8
       marked: 14.0.0
 
   mrmime@2.0.1: {}

--- a/src/module.ts
+++ b/src/module.ts
@@ -3,7 +3,7 @@ import { defineNuxtModule, addComponent, createResolver, addImports, addVitePlug
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 import type { Nuxt } from 'nuxt/schema'
 import vitePlugin from './vitePlugin'
-import { createRequire } from 'node:module'
+import { resolveMonacoPath } from './monacoPath'
 import defu from 'defu'
 
 export type MonacoEditorLocale = 'cs' | 'de' | 'es' | 'fr' | 'it' | 'ja' | 'ko' | 'pl' | 'pt-br' | 'qps-ploc' | 'ru' | 'tr' | 'zh-hans' | 'zh-hant' | 'en';
@@ -29,8 +29,6 @@ const getDefaults = (nuxt: Nuxt): Required<ModuleOptions> => {
     }
   }
 }
-
-const require = createRequire(import.meta.url)
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {
@@ -59,8 +57,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     addVitePlugin(viteStaticCopy({
       targets: [{
-        src: require
-          .resolve('monaco-editor/esm/metadata.js')
+        src: resolveMonacoPath('esm', 'metadata.js')
           .replace(/\\/g, '/')
           .replace(/\/metadata.js$/, '/*'),
         dest: '_nuxt/nuxt-monaco-editor'

--- a/src/monacoPath.ts
+++ b/src/monacoPath.ts
@@ -1,0 +1,40 @@
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+import { existsSync, readFileSync } from 'node:fs'
+
+const require = createRequire(import.meta.url)
+
+/**
+ * Locate the monaco-editor package root on disk.
+ * Deep paths like `monaco-editor/esm/...` break under 0.56+ package exports
+ * (which remap `./*` → `./esm/vs/*`), so resolve via the package entry instead.
+ */
+export function getMonacoEditorRoot (): string {
+  const entry = require.resolve('monaco-editor')
+  let dir = dirname(entry)
+
+  for (let i = 0; i < 10; i++) {
+    const pkgPath = join(dir, 'package.json')
+    if (existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { name?: string }
+        if (pkg.name === 'monaco-editor') {
+          return dir
+        }
+      } catch {
+        // continue walking
+      }
+    }
+    const parent = dirname(dir)
+    if (parent === dir) {
+      break
+    }
+    dir = parent
+  }
+
+  throw new Error(`Could not locate monaco-editor package root from ${entry}`)
+}
+
+export function resolveMonacoPath (...segments: string[]): string {
+  return join(getMonacoEditorRoot(), ...segments)
+}

--- a/src/monacoPath.ts
+++ b/src/monacoPath.ts
@@ -13,7 +13,7 @@ export function getMonacoEditorRoot (): string {
   const entry = require.resolve('monaco-editor')
   let dir = dirname(entry)
 
-  for (let i = 0; i < 10; i++) {
+  while (dir !== dirname(dir)) {
     const pkgPath = join(dir, 'package.json')
     if (existsSync(pkgPath)) {
       try {
@@ -25,11 +25,7 @@ export function getMonacoEditorRoot (): string {
         // continue walking
       }
     }
-    const parent = dirname(dir)
-    if (parent === dir) {
-      break
-    }
-    dir = parent
+    dir = dirname(dir)
   }
 
   throw new Error(`Could not locate monaco-editor package root from ${entry}`)

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -1,4 +1,4 @@
-import type Monaco from 'monaco-editor/esm/vs/editor/editor.api'
+import type * as Monaco from 'monaco-editor'
 
 let monacoPromise: Promise<typeof Monaco> | null = null
 

--- a/src/vitePlugin.ts
+++ b/src/vitePlugin.ts
@@ -1,31 +1,32 @@
 import { fileURLToPath } from 'node:url'
 import fs from 'fs/promises'
-import { createRequire } from 'node:module'
 import { createResolver } from '@nuxt/kit'
 import type { Plugin } from 'vite'
 import type { NuxtOptions } from 'nuxt/schema'
 import type { ModuleOptions } from './module'
+import { getMonacoEditorRoot } from './monacoPath'
+import { join } from 'node:path'
 
 const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))
 const { resolve } = createResolver(runtimeDir)
 const rewrittenMonacoFiles = new Map<string, string>()
 const nlsPath = resolve('nls.js')
 
-const { resolve: resolveModule } = createRequire(import.meta.url)
-
 const plugin = (options: Required<ModuleOptions>, nuxtOptions: NuxtOptions): Plugin => ({
   name: 'vite-plugin-nuxt-monaco-editor',
   enforce: 'pre',
   resolveId (src) {
     if (/monaco-editor\/esm\/vs\/.*\.worker\.js/.test(src)) {
-      return resolveModule(src
+      const cleaned = src
         .replace('?worker', '')
         .replace('__skip_vite', '')
         .replace('node_modules', '')
         .replace(nuxtOptions.app.baseURL, '/')
         .replace(/\/\/+/g, '/')
         .replace(/^\//, '')
-      )
+      // Avoid Node exports remapping (0.56+): resolve from package root on disk
+      const relative = cleaned.replace(/^monaco-editor\//, '')
+      return join(getMonacoEditorRoot(), relative)
     }
   },
   async load (id) {


### PR DESCRIPTION
Closes #78

## Summary
- Bumps `monaco-editor` to `^0.56.0` and fixes module setup / worker resolution that broke under the new package `exports` map.
- In 0.56, deep imports like `monaco-editor/esm/...` are remapped to `esm/vs/...`, which made `require.resolve('monaco-editor/esm/metadata.js')` fail during `nuxt prepare` (and broke worker path resolution).
- Resolves monaco files from the package root on disk instead of via deep export paths, so both 0.55.x and 0.56+ keep working.

## Changes
- Add `src/monacoPath.ts` helpers (`getMonacoEditorRoot`, `resolveMonacoPath`)
- Use filesystem-based resolution for Vite static copy (`src/module.ts`) and worker `resolveId` (`src/vitePlugin.ts`)
- Import types from `monaco-editor` package entry in `useMonaco`
- Also added submodule installation point to `Development` (I lost about 2 minutes debugging it😢)

P.S. I wanted to run tests, but it seems they are broken or doesn't launch locally on my machine. I got the same errors pre- and post-fix.